### PR TITLE
Add Eleventy templates and data

### DIFF
--- a/eleventy/.eleventy.js
+++ b/eleventy/.eleventy.js
@@ -1,0 +1,24 @@
+const dayCounter = require("./_includes/components/day-counter-template");
+const dayline = require("./_includes/components/dayline-template");
+const timelineIdx = require("./_includes/components/timeline-index-template");
+const pagination = require("./_includes/components/pagination-template");
+
+module.exports = function(eleventyConfig) {
+  eleventyConfig.addShortcode("daycounter", dayCounter);
+  eleventyConfig.addShortcode("dayline", dayline);
+  eleventyConfig.addShortcode("timelineindex", timelineIdx);
+  eleventyConfig.addShortcode("pagination", pagination);
+  return {
+    dir: {
+      input: '.',
+      includes: '_includes',
+      data: '_data',
+      output: '../_site'
+    },
+    templateFormats: ['njk', '11ty.js'],
+    htmlTemplateEngine: 'njk',
+    dataTemplateEngine: 'njk',
+    markdownTemplateEngine: 'njk',
+    incremental: true
+  };
+};

--- a/eleventy/_data/config.js
+++ b/eleventy/_data/config.js
@@ -1,0 +1,1 @@
+module.exports = require('../fixtures/config.json');

--- a/eleventy/_data/months.js
+++ b/eleventy/_data/months.js
@@ -1,0 +1,2 @@
+const months = require('../fixtures/months.json');
+module.exports = months;

--- a/eleventy/_data/timeline.js
+++ b/eleventy/_data/timeline.js
@@ -1,0 +1,8 @@
+const months = require('./months');
+const out = {};
+for(const m of months){
+  const year = m.date.slice(0,4);
+  if(!out[year]) out[year] = [];
+  out[year].push(m);
+}
+module.exports = out;

--- a/eleventy/_includes/components/day-counter-template.js
+++ b/eleventy/_includes/components/day-counter-template.js
@@ -1,0 +1,5 @@
+module.exports = function({dateSlug, label, count}) {
+  return `<li class="day" id="${dateSlug}">
+    <span class="title">${label} <span class="count">(${count} messages)</span></span>
+  </li>`;
+};

--- a/eleventy/_includes/components/dayline-template.js
+++ b/eleventy/_includes/components/dayline-template.js
@@ -1,0 +1,8 @@
+module.exports = function({dayline, month}) {
+  function makeFilename(m, page) {
+    return `${m.slug}${page > 1 ? '_' + page : ''}.html`;
+  }
+  return `<ul class="index">\n` +
+    dayline.map(d => `  <li class="day-${d.slug}"><a href="${makeFilename(month, d.page)}#${d.slug}">${d.label} <span class="count">(${d.count})</span></a></li>`).join("\n") +
+  `\n</ul>`;
+};

--- a/eleventy/_includes/components/pagination-template.js
+++ b/eleventy/_includes/components/pagination-template.js
@@ -1,0 +1,10 @@
+module.exports = function({current, total, month}) {
+  if(total <= 1) return '';
+  let out = '<ul class="pagination">';
+  for(let p=1;p<=total;p++) {
+    const cls = current === p ? 'active' : '';
+    out += `\n  <li class="${cls}"><a href="${month.slug}${p>1?'_'+p:''}.html">${p}</a></li>`;
+  }
+  out += '\n</ul>';
+  return out;
+};

--- a/eleventy/_includes/components/timeline-index-template.js
+++ b/eleventy/_includes/components/timeline-index-template.js
@@ -1,0 +1,15 @@
+module.exports = function({timeline, month}) {
+  let out = '<ul class="timeline index">';
+  Object.keys(timeline).sort().reverse().forEach(year => {
+    const months = timeline[year];
+    out += `\n<li><h3 class="year"><a href="${months[0].slug}.html">${year}</a></h3>`;
+    out += '\n<ul class="months">';
+    months.slice().reverse().forEach(m => {
+      const sel = m.slug === month.slug ? ' class="selected"' : '';
+      out += `\n  <li${sel}><a href="${m.slug}.html">${m.label} <span class="count">(${m.count})</span></a></li>`;
+    });
+    out += '\n</ul>\n</li>';
+  });
+  out += '\n</ul>';
+  return out;
+};

--- a/eleventy/_includes/layouts/template.njk
+++ b/eleventy/_includes/layouts/template.njk
@@ -1,0 +1,179 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	{% set page_title = config.page_title.format(group=config.group, date=month.label, page=pagination.current) %}
+	{% set meta_description = config.meta_description.format(group=config.group, date=config.date) %}
+	<title>{{ page_title }}</title>
+	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+	<meta name="description" content="{{ meta_description }}" />
+	<meta name="referrer" content="no-referrer">
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<link rel="shortcut icon" href="static/favicon.png" />
+
+	<meta property="og:title" content="{{ page_title }}" />
+	<meta property="og:description" content="{{ meta_description }}" />
+	<meta property="og:type" content="website" />
+	<meta property="og:url" content="{{ config.site_url }}/.html" />
+	<meta property="og:image" content="{{ config.site_url }}/static/thumb.png" />
+
+	{% if config.publish_rss_feed %}
+		<link rel="alternate" type="application/rss+xml" title="RSS feed " href="index.xml" />
+		<link rel="alternate" type="application/atom+xml" title="Atom feed " href="index.atom" />
+	{% endif %}
+
+	<link rel="preconnect" href="https://fonts.gstatic.com">
+	<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet"> 
+	<link href="static/style.css" rel="stylesheet" type="text/css" />	
+</head>
+<body>
+
+<div class="wrap">
+	<div class="container">
+		<nav class="nav">
+			<a href="./">@{{ config.group }}</a>
+			<label class="burger" for="burger" tabindex="0"><span></span><span></span><span></span></label>
+		</nav>
+		<input type="checkbox" id="burger" />
+
+		<section class="sidebar" id="sidebar">
+			<header class="header">
+				<div class="logo">
+					<a href="{{ config.site_url }}"><img src="static/logo.svg" alt="" /></a>
+					<p class="desc">
+						<a href="{{ config.telegram_url.format(id=config.group) }}" rel="noreferer nopener nofollow">@{{ config.group }}</a> /
+						{{ config.site_description.format(group=config.group, date=config.date) }}
+					</p>
+				</div>
+			</header>
+                        {{ timelineindex({timeline: timeline, month: month}) | safe }}
+
+			<footer class="footer">
+				{% if config.publish_rss_feed %}
+					<a href="index.xml">RSS feed.</a>
+				{% endif %} &nbsp;&nbsp;
+				Made with <a href="https://github.com/knadh/tg-archive">tg-archive</a>
+			</footer>
+		</section>
+
+		<section class="content">
+                        {% if pagination.total > 1 %}
+        {{ pagination({current: pagination.current, total: pagination.total, month: month}) | safe }}
+                        {% endif %}
+
+			<ul class="messages">
+				{% for m in messages %}
+					{% set day = m.date.strftime("%d %B %Y") %}
+					{% if loop.index0 == 0 or day != messages[loop.index0 - 1].date.strftime("%d %B %Y") %}
+{{ daycounter({dateSlug: m.date.strftime("%Y-%m-%d"), label: day, count: dayline[m.date.strftime("%Y-%m-%d")].count}) | safe }}
+					{% endif %}
+					<li class="message type-{{ m.type }}" id="{{ m.id }}">
+						<div class="avatar">
+							{% if m.user.avatar %}
+								<img src="{{ config.media_dir }}/{{ m.user.avatar }}" alt="" />
+							{% endif %}
+						</div>
+
+						<div class="body">
+							<div class="meta">
+								<a href="{{ config.telegram_url.format(id=m.user.username) }}" class="username" rel="noreferer nopener nofollow">
+									{% if config.show_sender_fullname %}
+										{{ m.user.first_name }} {{ m.user.last_name }} (@{{ m.user.username }})
+									{% else %}
+										@{{ m.user.username }}
+									{% endif %}
+								</a>
+
+								{% if m.reply_to %}
+									<a class="reply" href="{{ page_ids[m.reply_to] }}#{{ m.reply_to }}">↶ Reply to #{{ m.reply_to }}</a>
+								{% endif %}
+
+								<a class="id" href="#{{ m.id }}">#{{ m.id }}</a>
+
+								{% if m.user.tags %}
+									{% for t in m.user.tags %}
+										<span class="tags">{{ t }}</span>
+									{% endfor %}
+								{% endif %}
+
+								<span class="date">{{ m.date.strftime("%I:%M %p, %d %b %Y") }}</span>
+							</div>
+							<div class="text">
+								{% if m.type == "message" %}
+									{{ nl2br(m.content | escape) | safe | urlize }}
+								{% else %}
+									{% if m.type == "user_joined" %}
+										Joined.
+									{% elif m.type == "user_joined_by_link" %}
+										Joined by invite link.
+									{% elif m.type == "user_left" %}
+										Left.
+									{% endif %}
+								{% endif %}
+							</div>
+							{% if m.media %}
+								<div class="media">
+									{% if m.media.type == "webpage" and (m.media.title or m.media.description) %}
+										<a href="{{ m.media.url }}" rel="noreferer nopener nofollow">{{ m.media.title or "Link" }}</a>
+										{% if m.media.description %}
+											<p>{{ m.media.description }}</p>
+										{% endif %}
+									{% elif m.media.type == "poll" %}
+										<div class="poll">
+											<h4 class="title">{{ m.media.title }}</h4>
+											<span class="total-count">
+												{{ m.media.description | sum(attribute="count") }} vote(s).
+											</span>
+											<ul class="options">
+												{% for o in m.media.description %}
+													<li>
+														<span class="count">{{ o.percent }}%, {{ o.count }} votes</span>
+														<span class="bar" style="width: {{ o.percent }}%"></span>
+														<label>{{ o.label }}</label>
+													</li>
+												{% endfor %}
+											</ul>
+										</div>									
+									{% elif m.media.type == "photo" %}
+										{% set ext = m.media.url.split('/')[-1].split('.')[-1].lower() %}
+										{% if ext in ['mp4', 'webm', 'ogg', 'ogv', 'oga', 'mov'] %}
+											<video controls>
+												<source src="{{ config.media_dir }}/{{ m.media.url }}">
+											</video>
+											<p><a href="{{ config.media_dir }}/{{ m.media.url }}">{{ m.media.title }}</a></p>
+										{% elif ext in ['webp'] %}
+											<a href="{{ config.media_dir }}/{{ m.media.url }}">
+												<img src="{{ config.media_dir }}/{{ m.media.url }}" class="media-webp" />
+											</a>
+										{% elif m.media.thumb %}
+											<a href="{{ config.media_dir }}/{{ m.media.url }}">
+												<img src="{{ config.media_dir }}/{{ m.media.thumb }}" class="thumb" /><br />
+												<span class="filename">{{ m.media.title }}</span>
+											</a>
+										{% else %}
+											<a href="{{ config.media_dir }}/{{ m.media.url }}">{{ m.media.title }}</a>
+										{% endif %}
+									{% else %}
+										<a href="{{ config.media_dir }}/{{ m.media.url }}">{{ m.media.title }}</a>
+									{% endif %}
+								</div>
+							{% endif %}
+						</div>
+					</li>
+				{% endfor %}
+			</ul>
+
+{% if pagination.total > 1 %}
+        {{ pagination({current: pagination.current, total: pagination.total, month: month}) | safe }}
+{% endif %}
+		</section><!-- content -->
+
+		<section class="dayline">
+			{% if config.show_day_index %}
+        {{ dayline({dayline: dayline, month: month}) | safe }}
+			{% endif %}
+		</section>
+	</div><!-- container -->
+</div>
+<script src="static/main.js"></script>
+</body>
+</html>

--- a/eleventy/fixtures/config.json
+++ b/eleventy/fixtures/config.json
@@ -1,0 +1,37 @@
+{
+  "api_id": "123456",
+  "api_hash": "your_api_hash",
+  "group": "your_group_name or your_group_username or your_group_id(a negative number)",
+  "download_media": true,
+  "download_avatars": true,
+  "avatar_size": [
+    64,
+    64
+  ],
+  "media_dir": "media",
+  "media_mime_types": [],
+  "use_takeout": false,
+  "proxy": {
+    "enable": false,
+    "protocol": "socks5",
+    "addr": "127.0.0.1",
+    "port": 1080
+  },
+  "fetch_batch_size": 2000,
+  "fetch_wait": 5,
+  "fetch_limit": 0,
+  "publish_dir": "site",
+  "static_dir": "static",
+  "per_page": 500,
+  "show_day_index": true,
+  "telegram_url": "https://t.me/{id}",
+  "show_sender_fullname": false,
+  "timezone": "",
+  "publish_rss_feed": true,
+  "rss_feed_entries": 100,
+  "site_url": "https://mysite.com",
+  "site_name": "@{group} - Telegram group archive",
+  "site_description": "Public archive of Telegram messages.",
+  "meta_description": "@{group} {date} - Telegram message archive.",
+  "page_title": "Page {page} - {date} @{group} Telegram message archive."
+}

--- a/eleventy/fixtures/months.json
+++ b/eleventy/fixtures/months.json
@@ -1,0 +1,25 @@
+[
+  {
+    "slug": "2024-01",
+    "label": "Jan 2024",
+    "count": 1,
+    "date": "2024-01-01",
+    "messages": [
+      {
+        "id": 1,
+        "type": "message",
+        "date": "2024-01-01T10:00:00Z",
+        "content": "Hello world",
+        "user": {
+          "username": "user1",
+          "first_name": "User",
+          "last_name": "One",
+          "avatar": ""
+        }
+      }
+    ],
+    "dayline": [
+      {"slug": "2024-01-01", "label": "01 Jan 2024", "count": 1, "page": 1, "date": "2024-01-01"}
+    ]
+  }
+]

--- a/eleventy/month.njk
+++ b/eleventy/month.njk
@@ -1,0 +1,12 @@
+---
+pagination:
+  data: months
+  size: 1
+  alias: month
+permalink: "{{ month.slug }}{% if pagination.pageNumber > 0 %}_{{ pagination.pageNumber + 1 }}{% endif %}.html"
+---
+{% set total_pages = (month.messages | length / config.per_page) | ceil %}
+{% set messages = month.messages | slice(pagination.pageNumber * config.per_page, config.per_page) %}
+{% set dayline = month.dayline %}
+{% set pagination = {current: pagination.pageNumber + 1, total: total_pages} %}
+{% include "layouts/template.njk" %}

--- a/eleventy/package.json
+++ b/eleventy/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "tg-archive-eleventy",
+  "private": true,
+  "scripts": {
+    "build": "eleventy"
+  },
+  "dependencies": {
+    "@11ty/eleventy": "^2.0.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add Eleventy config with shortcodes
- convert Jinja template to Nunjucks layout
- add JS templates for timeline index, pagination, dayline and day counter
- wire up Eleventy data using JSON fixtures

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
