### PR TITLE
Add feed generation helper

### DIFF
--- a/fixtures/latest_messages.json
+++ b/fixtures/latest_messages.json
@@ -1,0 +1,24 @@
+[
+  {
+    "id": 1001,
+    "date": "2025-03-01T12:34:56Z",
+    "page": "2025-03.html",
+    "content": "Hello world",
+    "user": {"username": "alice"}
+  },
+  {
+    "id": 1002,
+    "date": "2025-03-01T13:00:00Z",
+    "page": "2025-03.html",
+    "content": "Picture of a cat",
+    "user": {"username": "bob"},
+    "media": {"url": "photo_1.jpg", "mime": "image/jpeg", "length": 0}
+  },
+  {
+    "id": 1003,
+    "date": "2025-03-02T08:15:00Z",
+    "page": "2025-03.html",
+    "content": "Another message",
+    "user": {"username": "carol"}
+  }
+]

--- a/fixtures/rss_metadata.json
+++ b/fixtures/rss_metadata.json
@@ -1,0 +1,8 @@
+{
+  "site_url": "https://mysite.com",
+  "site_name": "@{group} - Telegram group archive",
+  "site_description": "Public archive of Telegram messages.",
+  "group": "example",
+  "version": "1.3.0",
+  "media_dir": "media"
+}

--- a/scripts/generateFeed.js
+++ b/scripts/generateFeed.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const path = require('path');
+const { Feed } = require('feed');
+
+const meta = JSON.parse(fs.readFileSync(path.join(__dirname, '../fixtures/rss_metadata.json'), 'utf8'));
+const messages = JSON.parse(fs.readFileSync(path.join(__dirname, '../fixtures/latest_messages.json'), 'utf8'));
+
+const feed = new Feed({
+  id: meta.site_url,
+  title: meta.site_name.replace('{group}', meta.group),
+  description: meta.site_description,
+  generator: `tg-archive ${meta.version}`,
+  link: meta.site_url
+});
+
+messages.forEach(msg => {
+  const url = `${meta.site_url}/${msg.page}#${msg.id}`;
+  const item = {
+    id: url,
+    title: `@${msg.user.username} on ${msg.date} (#${msg.id})`,
+    link: url,
+    date: new Date(msg.date),
+    description: msg.content || ''
+  };
+  if (msg.media) {
+    item.enclosure = {
+      url: `${meta.site_url}/${meta.media_dir}/${msg.media.url}`,
+      type: msg.media.mime,
+      length: msg.media.length
+    };
+  }
+  feed.addItem(item);
+});
+
+fs.writeFileSync(path.join(__dirname, '../index.xml'), feed.rss2());
+fs.writeFileSync(path.join(__dirname, '../index.atom'), feed.atom1());
+


### PR DESCRIPTION
## Summary
- provide example metadata and sample messages fixtures
- add a Node script that uses the `feed` package
- output `index.xml` and `index.atom` from fixture data

## Testing
- `python -m py_compile $(git ls-files '*.py')`